### PR TITLE
Adding LinkedIn to speaker cards

### DIFF
--- a/src/components/speakerItem.js
+++ b/src/components/speakerItem.js
@@ -5,7 +5,15 @@ import './../styles/speakerItem.scss';
 
 // Speakears item component
 
-const SpeakerItem = ({ pic, name, description, github, facebook, twitter }) => {
+const SpeakerItem = ({
+  pic,
+  name,
+  description,
+  github,
+  facebook,
+  twitter,
+  linkedin,
+}) => {
   return (
     <article className="speakers-grid__item">
       <figure className="speakers-grid__figure">
@@ -19,24 +27,38 @@ const SpeakerItem = ({ pic, name, description, github, facebook, twitter }) => {
       <div className="speakers-grid__description">
         <p className="speakers-grid__text">{description}</p>
         <div className="speakers-grid__social">
-          <a
-            href={github}
-            className="speakers-grid__link speakers-grid__link--github"
-          >
-            Github
-          </a>
-          <a
-            href={facebook}
-            className="speakers-grid__link speakers-grid__link--facebook"
-          >
-            Facebook
-          </a>
-          <a
-            href={twitter}
-            className="speakers-grid__link speakers-grid__link--twitter"
-          >
-            Twitter
-          </a>
+          {!!github && (
+            <a
+              href={github}
+              className="speakers-grid__link speakers-grid__link--github"
+            >
+              Github
+            </a>
+          )}
+          {!!facebook && (
+            <a
+              href={facebook}
+              className="speakers-grid__link speakers-grid__link--facebook"
+            >
+              Facebook
+            </a>
+          )}
+          {!!twitter && (
+            <a
+              href={twitter}
+              className="speakers-grid__link speakers-grid__link--twitter"
+            >
+              Twitter
+            </a>
+          )}
+          {!!linkedin && (
+            <a
+              href={linkedin}
+              className="speakers-grid__link speakers-grid__link--linkedin"
+            >
+              linkedin
+            </a>
+          )}
         </div>
       </div>
     </article>
@@ -50,6 +72,7 @@ SpeakerItem.propTypes = {
   github: PropTypes.string,
   facebook: PropTypes.string,
   twitter: PropTypes.string,
+  linkedin: PropTypes.string,
 };
 
 export default SpeakerItem;

--- a/src/images/linkedin_logo.svg
+++ b/src/images/linkedin_logo.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="510px" height="510px" viewBox="0 0 510 510" style="enable-background:new 0 0 510 510;" xml:space="preserve">
+<g>
+	<g id="post-linkedin">
+		<path d="M459,0H51C22.95,0,0,22.95,0,51v408c0,28.05,22.95,51,51,51h408c28.05,0,51-22.95,51-51V51C510,22.95,487.05,0,459,0z
+			 M153,433.5H76.5V204H153V433.5z M114.75,160.65c-25.5,0-45.9-20.4-45.9-45.9s20.4-45.9,45.9-45.9s45.9,20.4,45.9,45.9
+			S140.25,160.65,114.75,160.65z M433.5,433.5H357V298.35c0-20.399-17.85-38.25-38.25-38.25s-38.25,17.851-38.25,38.25V433.5H204
+			V204h76.5v30.6c12.75-20.4,40.8-35.7,63.75-35.7c48.45,0,89.25,40.8,89.25,89.25V433.5z"/>
+	</g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/src/styles/speakerItem.scss
+++ b/src/styles/speakerItem.scss
@@ -105,4 +105,8 @@
   &--github {
     background-image: url('./../images/github_logo.svg');
   }
+
+  &--linkedin {
+    background-image: url('./../images/linkedin_logo.svg');
+  }
 }


### PR DESCRIPTION
@sgomezglobant this adds LinkedIn to the speakers card and also render only the necessary cards (no more - it was always rendering `twitter`, `facebook` and `github`)

We'd need a new LinkedIn logo, I grab this from the internet but its color doesn't match the other social logos on the page (see image) - please, add a new logo before merging this!

![screen shot 2019-02-13 at 5 31 15 pm](https://user-images.githubusercontent.com/464978/52748883-b2641400-2fb5-11e9-965c-4bc206189235.png)

Thanks,