### PR TITLE
Activating offline for pwa

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -24,12 +24,12 @@ module.exports = {
         start_url: `/`,
         background_color: `#7eb51e`,
         theme_color: `#7eb51e`,
-        display: `minimal-ui`,
+        display: `standalone`,
         icon: `src/images/reactweek-logo.png` // This path is relative to the root of the site.
       }
-    }
+    },
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.app/offline
-    // 'gatsby-plugin-offline',
+    'gatsby-plugin-offline'
   ]
 };


### PR DESCRIPTION
Habilitando el plugin offline para poder activarlo como PWA.

URL: https://my-gatsby-project-msq3m55xm.now.sh/

Lighthouse Audit:
![image](https://user-images.githubusercontent.com/2708687/53543476-ca2cb380-3af0-11e9-85e0-7955e518613e.png)

iPhone:
_Hay un issue a veces con la imagen del ícono como ahora pero en otro build no me salió así. Supongo que es por el soporte del PWA en iPhone._
Así se ve actualmente.
![image](https://user-images.githubusercontent.com/2708687/53543758-be8dbc80-3af1-11e9-891a-a549579f61b4.png)
![image](https://user-images.githubusercontent.com/2708687/53543816-f09f1e80-3af1-11e9-9d29-cdf367ccadcb.png)

No tengo Android así que si alguno me ayuda viéndolo en Android sería genial.
